### PR TITLE
修改配置防止远程部署需要经常手改代码和处理冲突

### DIFF
--- a/client/src/app.ts
+++ b/client/src/app.ts
@@ -3,8 +3,8 @@ import JSMpeg from '@cycjimmy/jsmpeg-player';
 import flvjs from 'flv.js';
 
 const Config = {
-    'SOCKET_URL': 'ws://localhost:8000',
-    'VIDEO_URL': 'ws://localhost:9999',
+    'SOCKET_URL': `ws://${window.location.hostname}:3100`,
+    'VIDEO_URL': `ws://${window.location.hostname}:3101`,
     'PLAYER_WIDTH': 1280,
     'PLAYER_HEIGHT': 720,
 }

--- a/client/webpack.dev.config.js
+++ b/client/webpack.dev.config.js
@@ -33,7 +33,7 @@ module.exports = {
         })
     ],
     devServer: {
-        host: '127.0.0.1',
         port: 8000,
+        allowedHosts: 'all'
     }
 }

--- a/server/entry-server.js
+++ b/server/entry-server.js
@@ -6,8 +6,8 @@ const { CliParse, CliCreate, Log, Warnning } = require('./utils');
 const Config = {
     WINDOW_WIDTH: 1280,
     WINDOW_HEIGHT: 720,
-    COMMAND_WS_PORT: 8000,
-    VIDEO_WS_PORT: 9999,
+    COMMAND_WS_PORT: 3100,
+    VIDEO_WS_PORT: 3101,
     VIDEO_FPS: 30,
     // PAGE_URL: 'chrome://gpu',
     // PAGE_URL: 'http://naiteluo.cc/mondrian/index.html',


### PR DESCRIPTION
- 修改web的ws地址，动态获取当前 hostname
- 修改webpack配置支持所有host访问
- 修改web、ws端口为目前远程机器上已开放安全权限的端口（web 8100、COMMAND_WS_PORT 3100、VIDEO_WS_PORT 3101）